### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-jose==3.3.0
 boto3==1.34.14
 botocore==1.34.14
 httpx==0.26.0
+requests


### PR DESCRIPTION
Missing `requests` dependency (imported in `elastic_proxy_utils.py`). Didn't specify exact version but leaving this here so we don't forget!